### PR TITLE
do not broadcast a message back to the server

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, io::BufRead};
+use std::{collections::{HashSet, HashMap}, io::BufRead};
 
 use gossip_glomers::{
     broadcast::Broadcast,
@@ -15,6 +15,7 @@ fn main() -> anyhow::Result<()> {
     let mut broadcast = Broadcast {
         messages: HashSet::new(),
         neighborhood: HashSet::new(),
+        received_from: HashMap::new(),
     };
 
     // Use the lines iterator from the io::BufRead trait.
@@ -62,6 +63,9 @@ fn main() -> anyhow::Result<()> {
                             payload: Payload::BroadcastOk,
                         },
                     };
+
+                    // persist the message and its origin
+                    broadcast.received_from.insert(message, input.src);
 
                     // ack the received broadcast
                     broadcast.send_reply(reply)?;


### PR DESCRIPTION
we often broadcast a message back to the server which sent it to us. That's extra work we don't actually need to perform. Let's add a check to skip it:

```rust
            if let Some(node) = self.received_from.get(&message) {
                // someone sent us this msg, let's see if it's the node we are about to send it back to
                if node != neighbor {
                    // someone else sent this to us, so it's ok to send it back
                    self.send_reply(gossip_message)?;
                } else {
                    // oh no, it is the same node, skip it
                }
            }
        }
```